### PR TITLE
Add options to either ignore or remove unknown migrations

### DIFF
--- a/Sources/PostgresMigrations/MigrationError.swift
+++ b/Sources/PostgresMigrations/MigrationError.swift
@@ -34,7 +34,7 @@ public struct DatabaseMigrationError: Error, Equatable {
     /// Applied migrations are inconsistent with expected list
     public static var appliedMigrationsInconsistent: Self { .init(.appliedMigrationsInconsistent) }
     /// Cannot revert a migration as we do not have its details. Add it to the revert list using
-    /// PostgresMigrations.add(revert:)
+    /// PostgresMigrations.register()
     public static var cannotRevertMigration: Self { .init(.cannotRevertMigration) }
 }
 
@@ -45,7 +45,7 @@ extension DatabaseMigrationError: CustomStringConvertible {
         case .requiresChanges: "Database requires changes. Run `migrate` with `dryRun` set to false."
         case .appliedMigrationsInconsistent: "Applied migrations are inconsistent with expected list."
         case .cannotRevertMigration:
-            "Cannot revert migration because we don't have its details. Use `PostgresMigrations.register` to register the DatabaseMigration."
+            "Cannot revert migration because we don't have its details. Use `PostgresMigrations.register` to register the DatabaseMigration or remove its database entry using option `.removeUnknownMigrations`."
         }
     }
 }

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -50,11 +50,11 @@ public actor DatabaseMigrations {
 
     /// Add migrations to list of migrations to be be applied
     /// - Parameters
-    ///   - migration: DatabaseMigration to be applied
+    ///   - migrations: Collection of DatabaseMigrations to be applied
     ///   - skipDuplicates: Only add migration if it doesn't exist in the list
     public func add(_ migrations: some Collection<DatabaseMigration>, skipDuplicates: Bool = false) {
         for migration in migrations {
-            self.add(migration)
+            self.add(migration, skipDuplicates: skipDuplicates)
         }
     }
 
@@ -66,7 +66,7 @@ public actor DatabaseMigrations {
         self.reverts[migration.name] = migration
     }
 
-    /// Options in ``DatabaseMigrations/revertInconsistent(client:group:options:logger:dryRun:)``.
+    /// Options used in ``DatabaseMigrations/apply(client:group:options:logger:dryRun:)``.
     public struct ApplyOptions: OptionSet, Sendable {
         public let rawValue: Int
 
@@ -170,7 +170,7 @@ public actor DatabaseMigrations {
         self.setCompleted()
     }
 
-    /// Options in ``DatabaseMigrations/revertInconsistent(client:group:options:logger:dryRun:)``.
+    /// Options used in ``DatabaseMigrations/revert(client:group:options:logger:dryRun:)``.
     public struct RevertOptions: OptionSet, Sendable {
         public let rawValue: Int
 
@@ -268,7 +268,7 @@ public actor DatabaseMigrations {
         }
     }
 
-    /// Options in ``DatabaseMigrations/revertInconsistent(client:group:options:logger:dryRun:)``.
+    /// Options used in ``DatabaseMigrations/revertInconsistent(client:group:options:logger:dryRun:)``.
     public struct RevertInconsistentOptions: OptionSet, Sendable {
         public let rawValue: Int
 

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -52,7 +52,7 @@ public actor DatabaseMigrations {
     /// - Parameters
     ///   - migrations: Collection of DatabaseMigrations to be applied
     ///   - skipDuplicates: Only add migration if it doesn't exist in the list
-    public func add(_ migrations: some Collection<any DatabaseMigration>, skipDuplicates: Bool = false) {
+    public func add(contentsOf migrations: some Collection<any DatabaseMigration>, skipDuplicates: Bool = false) {
         for migration in migrations {
             self.add(migration, skipDuplicates: skipDuplicates)
         }
@@ -66,7 +66,7 @@ public actor DatabaseMigrations {
         self.reverts[migration.name] = migration
     }
 
-    /// Options used in ``DatabaseMigrations/apply(client:group:options:logger:dryRun:)``.
+    /// Options used in ``DatabaseMigrations/apply(client:groups:options:logger:dryRun:)``.
     public struct ApplyOptions: OptionSet, Sendable {
         public let rawValue: Int
 
@@ -170,7 +170,7 @@ public actor DatabaseMigrations {
         self.setCompleted()
     }
 
-    /// Options used in ``DatabaseMigrations/revert(client:group:options:logger:dryRun:)``.
+    /// Options used in ``DatabaseMigrations/revert(client:groups:options:logger:dryRun:)``.
     public struct RevertOptions: OptionSet, Sendable {
         public let rawValue: Int
 
@@ -269,7 +269,7 @@ public actor DatabaseMigrations {
         }
     }
 
-    /// Options used in ``DatabaseMigrations/revertInconsistent(client:group:options:logger:dryRun:)``.
+    /// Options used in ``DatabaseMigrations/revertInconsistent(client:groups:options:logger:dryRun:)``.
     public struct RevertInconsistentOptions: OptionSet, Sendable {
         public let rawValue: Int
 
@@ -300,8 +300,8 @@ public actor DatabaseMigrations {
     ///
     /// For a migration to be removed it has to have been registered either using
     /// ``DatabaseMigrations/add(_:skipDuplicates:)`` or ``DatabaseMigrations/register(_:)``. If a migration name
-    /// is found that has no associated migration then a ``DatabaseMigrationError.cannotRevertMigration`` error is
-    /// thrown. You can avoid this error by including the option ``RevertInconsistentOptions.removeUnknownMigrations``
+    /// is found that has no associated migration then a ``DatabaseMigrationError/cannotRevertMigration`` error is
+    /// thrown. You can avoid this error by including the option ``RevertInconsistentOptions/removeUnknownMigrations``
     /// which will remove database entries for migrations that haven't been registered.
     ///
     /// - Parameters:

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -52,7 +52,7 @@ public actor DatabaseMigrations {
     /// - Parameters
     ///   - migrations: Collection of DatabaseMigrations to be applied
     ///   - skipDuplicates: Only add migration if it doesn't exist in the list
-    public func add(_ migrations: some Collection<DatabaseMigration>, skipDuplicates: Bool = false) {
+    public func add(_ migrations: some Collection<any DatabaseMigration>, skipDuplicates: Bool = false) {
         for migration in migrations {
             self.add(migration, skipDuplicates: skipDuplicates)
         }

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -73,7 +73,7 @@ public actor DatabaseMigrations {
         public init(rawValue: Int) { self.rawValue = rawValue }
 
         /// If database has a migration applied we don't know about, ignore it
-        static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
+        public static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
     }
 
     /// Apply database migrations
@@ -177,9 +177,9 @@ public actor DatabaseMigrations {
         public init(rawValue: Int) { self.rawValue = rawValue }
 
         /// Ignore migrations we don't know about
-        static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
+        public static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
         /// Remove database entry for migrations we don't know about
-        static var removeUnknownMigrations: Self { .init(rawValue: 1 << 1) }
+        public static var removeUnknownMigrations: Self { .init(rawValue: 1 << 1) }
     }
 
     /// Revert database migrations
@@ -276,9 +276,9 @@ public actor DatabaseMigrations {
         public init(rawValue: Int) { self.rawValue = rawValue }
 
         /// Ignore migrations we don't know about
-        static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
+        public static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
         /// Remove database entry for migrations we don't know about
-        static var removeUnknownMigrations: Self { .init(rawValue: 1 << 1) }
+        public static var removeUnknownMigrations: Self { .init(rawValue: 1 << 1) }
         /// Disable the reverting of migrations that follow an applied migration that is inconsistent
         ///
         /// The default for revertInconsistent is to revert all migrations after finding one that is inconsistent.
@@ -288,7 +288,7 @@ public actor DatabaseMigrations {
         ///
         /// Using this option means `revertInconsistent` cannot fix the migration list if the order of
         /// migrations has changed.
-        static var disableRevertsFollowingRevert: Self { .init(rawValue: 1 << 2) }
+        public static var disableRevertsFollowingRevert: Self { .init(rawValue: 1 << 2) }
     }
 
     /// Revert database migrations that are inconsistent with the migration list

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -48,6 +48,16 @@ public actor DatabaseMigrations {
         self.migrations.append(migration)
     }
 
+    /// Add migrations to list of migrations to be be applied
+    /// - Parameters
+    ///   - migration: DatabaseMigration to be applied
+    ///   - skipDuplicates: Only add migration if it doesn't exist in the list
+    public func add(_ migrations: some Collection<DatabaseMigration>, skipDuplicates: Bool = false) {
+        for migration in migrations {
+            self.add(migration)
+        }
+    }
+
     /// Register migration without it being applied
     ///
     /// This is useful for migrations you might have to revert.

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -279,10 +279,15 @@ public actor DatabaseMigrations {
         static var ignoreUnknownMigrations: Self { .init(rawValue: 1 << 0) }
         /// Remove database entry for migrations we don't know about
         static var removeUnknownMigrations: Self { .init(rawValue: 1 << 1) }
-        /// Disable the reverting of migrations that follow the revert of an applied migration that is
-        /// not in the migration list
+        /// Disable the reverting of migrations that follow an applied migration that is inconsistent
         ///
+        /// The default for revertInconsistent is to revert all migrations after finding one that is inconsistent.
+        /// The logic behind this is that removing that migration but not the following migrations will
+        /// leave the database structure in indeterminate state. But this is a destructive action and
+        /// you can disable this with this option.
         ///
+        /// Using this option means `revertInconsistent` cannot fix the migration list if the order of
+        /// migrations has changed.
         static var disableRevertsFollowingRevert: Self { .init(rawValue: 1 << 2) }
     }
 
@@ -291,7 +296,7 @@ public actor DatabaseMigrations {
     /// This will revert any migrations in the applied migration list after an inconsistency has been found in
     /// list eg a migration is missing or the order of migrations has changed. This is a destructive action
     /// so it is best to run this with dryRun set to true before running it without so you know what migrations
-    /// it will revert.
+    /// it will revert. You can control this using the options parameter.
     ///
     /// For a migration to be removed it has to have been registered either using
     /// ``DatabaseMigrations/add(_:skipDuplicates:)`` or ``DatabaseMigrations/register(_:)``. If a migration name

--- a/Tests/PostgresMigrationsTests/MigrationTests.swift
+++ b/Tests/PostgresMigrationsTests/MigrationTests.swift
@@ -340,6 +340,21 @@ final class MigrationTests: XCTestCase {
                 XCTFail()
             } catch let error as DatabaseMigrationError where error == .cannotRevertMigration {
             }
+            // Run revert ignoring unknown migrations
+            try await migrations.revertInconsistent(
+                client: client,
+                groups: [.default],
+                options: .ignoreUnknownMigrations,
+                logger: Self.logger,
+                dryRun: false
+            )
+            var appliedMigrations = try await getAll(client: client)
+            XCTAssertEqual(appliedMigrations.count, 3)
+            XCTAssertEqual(appliedMigrations[0], "test1")
+            XCTAssertEqual(appliedMigrations[1], "test2")
+            XCTAssertEqual(appliedMigrations[2], "test3")
+
+            // Run revert removing unknown migrations
             try await migrations.revertInconsistent(
                 client: client,
                 groups: [.default],
@@ -347,9 +362,9 @@ final class MigrationTests: XCTestCase {
                 logger: Self.logger,
                 dryRun: false
             )
-            let migrations = try await getAll(client: client)
-            XCTAssertEqual(migrations.count, 1)
-            XCTAssertEqual(migrations[0], "test1")
+            appliedMigrations = try await getAll(client: client)
+            XCTAssertEqual(appliedMigrations.count, 1)
+            XCTAssertEqual(appliedMigrations[0], "test1")
         }
     }
 


### PR DESCRIPTION
Add new options parameter to `apply`, `revert` and `revertInconsistent`. 
`apply` has option `.ignoreUnknownMigrations`
`revert` has options `.ignoreUnknownMigrations` and `.removeUnknownMigrations`
`revertInconsistent` has options `.ignoreUnknownMigrations` and `.removeUnknownMigrations`

Also added `Migrations.add(_:skipDuplicates:)` which takes `some Collection<any DatabaseMigration>`