### PR TITLE
Fix printMigrationComparison crash when expected list has a short first row

### DIFF
--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -474,7 +474,8 @@ public actor DatabaseMigrations {
     }
 
     nonisolated func printMigrationComparison(expected expectedList: [String], applied appliedList: [String], logger: Logger) {
-        let maxLength = max((expectedList.max { $0.count > $1.count }?.count ?? 0) + 4, 13)
+        let longestExpected = expectedList.lazy.map(\.count).max() ?? 0
+        let maxLength = max(longestExpected + 4, 13)
         func printLine(expected: String, applied: String) {
             let gap = String(repeating: " ", count: maxLength - expected.count)
             logger.error("\(expected)\(gap)\(applied)")

--- a/Tests/PostgresMigrationsTests/PrintMigrationComparisonTests.swift
+++ b/Tests/PostgresMigrationsTests/PrintMigrationComparisonTests.swift
@@ -1,0 +1,73 @@
+import Logging
+import Testing
+
+@testable import PostgresMigrations
+
+@Suite("printMigrationComparison")
+struct PrintMigrationComparisonTests {
+
+    @Test("does not trap when later rows are longer than the first expected entry")
+    func longerLaterRows() async {
+        await #expect(processExitsWith: .success) {
+            let logger = Logger(label: "postgres-migrations.test.print")
+            let migrations = DatabaseMigrations()
+            migrations.printMigrationComparison(
+                expected: ["A", "ShorterThanButStillLongerThanFive"],
+                applied: ["A"],
+                logger: logger
+            )
+        }
+    }
+
+    @Test("does not trap when applied list is longer than every expected entry")
+    func appliedLongerThanExpected() async {
+        await #expect(processExitsWith: .success) {
+            let logger = Logger(label: "postgres-migrations.test.print")
+            let migrations = DatabaseMigrations()
+            migrations.printMigrationComparison(
+                expected: ["Short", "Tiny"],
+                applied: ["AnExtremelyLongAppliedMigrationNameThatExceedsEveryExpectedEntry"],
+                logger: logger
+            )
+        }
+    }
+
+    @Test("handles empty expected list without trapping")
+    func emptyExpectedList() async {
+        await #expect(processExitsWith: .success) {
+            let logger = Logger(label: "postgres-migrations.test.print")
+            let migrations = DatabaseMigrations()
+            migrations.printMigrationComparison(
+                expected: [],
+                applied: ["AnythingGoes"],
+                logger: logger
+            )
+        }
+    }
+
+    @Test("handles single long expected entry")
+    func singleLongExpected() async {
+        await #expect(processExitsWith: .success) {
+            let logger = Logger(label: "postgres-migrations.test.print")
+            let migrations = DatabaseMigrations()
+            migrations.printMigrationComparison(
+                expected: ["AMigrationWithAReasonablyLongIdentifier"],
+                applied: [],
+                logger: logger
+            )
+        }
+    }
+
+    @Test("handles both lists empty")
+    func bothEmpty() async {
+        await #expect(processExitsWith: .success) {
+            let logger = Logger(label: "postgres-migrations.test.print")
+            let migrations = DatabaseMigrations()
+            migrations.printMigrationComparison(
+                expected: [],
+                applied: [],
+                logger: logger
+            )
+        }
+    }
+}

--- a/Tests/PostgresMigrationsTests/PrintMigrationComparisonTests.swift
+++ b/Tests/PostgresMigrationsTests/PrintMigrationComparisonTests.swift
@@ -1,3 +1,4 @@
+#if compiler(>=6.2)
 import Logging
 import Testing
 
@@ -71,3 +72,4 @@ struct PrintMigrationComparisonTests {
         }
     }
 }
+#endif


### PR DESCRIPTION
### AI Disclaimer

Claude identified and fixed this issue. I have verified the issue and the fix.

### What

In `printMigrationComparison`,

```
let maxLength = max((expectedList.max { $0.count > $1.count }?.count ?? 0) + 4, 13)
```

mistakenly uses `>` instead of `<` which would have resulted in the expected order since `.max(by:)` takes an `areInIncreasingOrder` predicate.

### Impact

Instead of the intended `DatabaseMigrationError.appliedMigrationsInconsistent`, a Swift runtime trap is hit. The diff output is truncated to one misleading row before the crash, making the real cause hard to diagnose.

### Fix

Use the correct ordering and slightly re-write for clarity.

### Tests

New PrintMigrationComparisonTests suite with 5 cases.